### PR TITLE
copy-source: Fix indexing wrong repo

### DIFF
--- a/src/ferryd/core/api.go
+++ b/src/ferryd/core/api.go
@@ -122,7 +122,7 @@ func (m *Manager) CopySource(repoID, target, sourceID string, release int) error
 		return err
 	}
 
-	return m.Index(repoID)
+	return m.Index(target)
 }
 
 // TrimObsolete will ask the repo to remove obsolete packages


### PR DESCRIPTION
The copy-source action, which copies a package relnum from repo A to repo B, was previously indexing repo A after the copy was over. This meant that a manual re-index of repo B was necessary after doing a cherry-pick before packages would show up in the index.

As it doesn't make any logical sense for us to re-index a repo that is unmodified let's assume that the original intent was to re-index the modified repo and adjust the code accordingly.