### PR TITLE
copy-source: Add skip-index flag

### DIFF
--- a/src/ferryctl/cmd/copy_source.go
+++ b/src/ferryctl/cmd/copy_source.go
@@ -26,6 +26,10 @@ import (
 	"github.com/getsolus/ferryd/src/libferry"
 )
 
+var (
+	skipIndex bool
+)
+
 var copySourceCmd = &cobra.Command{
 	Use:   "source [fromRepo] [targetRepo] [sourceName] [releaseNumber]",
 	Short: "copy packages by source name",
@@ -35,6 +39,7 @@ var copySourceCmd = &cobra.Command{
 
 func init() {
 	CopyCmd.AddCommand(copySourceCmd)
+	CopyCmd.PersistentFlags().BoolVarP(&skipIndex, "skip-index", "si", false, "Skip updating the index of the target")
 }
 
 func copySource(cmd *cobra.Command, args []string) {
@@ -74,7 +79,7 @@ func copySource(cmd *cobra.Command, args []string) {
 	client := libferry.NewClient(socketPath)
 	defer client.Close()
 
-	if err := client.CopySource(repoID, targetID, sourceID, sourceRelease); err != nil {
+	if err := client.CopySource(repoID, targetID, sourceID, sourceRelease, skipIndex); err != nil {
 		fmt.Fprintf(os.Stderr, "Error while copying source: %v\n", err)
 		return
 	}

--- a/src/ferryd/core/api.go
+++ b/src/ferryd/core/api.go
@@ -107,7 +107,7 @@ func (m *Manager) RemoveSource(repoID, sourceID string, release int) error {
 }
 
 // CopySource will ask the repo to copy all matching source==release packages
-func (m *Manager) CopySource(repoID, target, sourceID string, release int) error {
+func (m *Manager) CopySource(repoID, target, sourceID string, release int, skipIndex bool) error {
 	sourceRepo, err := m.repo.GetRepo(m.db, repoID)
 	if err != nil {
 		return err
@@ -122,7 +122,11 @@ func (m *Manager) CopySource(repoID, target, sourceID string, release int) error
 		return err
 	}
 
-	return m.Index(target)
+	if skipIndex {
+		return m.Index(target)
+	} else {
+		return nil
+	}
 }
 
 // TrimObsolete will ask the repo to remove obsolete packages

--- a/src/ferryd/handlers.go
+++ b/src/ferryd/handlers.go
@@ -270,9 +270,10 @@ func (s *Server) CopySource(w http.ResponseWriter, r *http.Request, p httprouter
 		"release":    req.Release,
 		"from":       sourceRepo,
 		"to":         req.Target,
+		"skipIndex":  req.SkipIndex,
 	}).Info("Source copy requested")
 
-	s.jproc.PushJob(jobs.NewCopySourceJob(sourceRepo, req.Target, req.Source, req.Release))
+	s.jproc.PushJob(jobs.NewCopySourceJob(sourceRepo, req.Target, req.Source, req.Release, req.SkipIndex))
 }
 
 // TrimPackages will proxy a job to remove excess fat from a repo

--- a/src/ferryd/jobs/copy_source.go
+++ b/src/ferryd/jobs/copy_source.go
@@ -27,41 +27,47 @@ import (
 
 // CopySourceJobHandler is responsible for removing packages by identifiers
 type CopySourceJobHandler struct {
-	repoID  string
-	target  string
-	source  string
-	release int
+	repoID    string
+	target    string
+	source    string
+	release   int
+	skipIndex bool
 }
 
 // NewCopySourceJob will return a job suitable for adding to the job processor
-func NewCopySourceJob(repoID, target, source string, release int) *JobEntry {
+func NewCopySourceJob(repoID, target, source string, release int, skipIndex bool) *JobEntry {
 	return &JobEntry{
 		sequential: true,
 		Type:       CopySource,
-		Params:     []string{repoID, target, source, fmt.Sprintf("%d", release)},
+		Params:     []string{repoID, target, source, fmt.Sprintf("%d", release), fmt.Sprintf("%t", skipIndex)},
 	}
 }
 
 // NewCopySourceJobHandler will create a job handler for the input job and ensure it validates
 func NewCopySourceJobHandler(j *JobEntry) (*CopySourceJobHandler, error) {
-	if len(j.Params) != 4 {
+	if len(j.Params) != 5 {
 		return nil, fmt.Errorf("job has invalid parameters")
 	}
 	rel, err := strconv.ParseInt(j.Params[3], 10, 32)
 	if err != nil {
 		return nil, err
 	}
+	si, err := strconv.ParseBool(j.Params[4])
+	if err != nil {
+		return nil, err
+	}
 	return &CopySourceJobHandler{
-		repoID:  j.Params[0],
-		target:  j.Params[1],
-		source:  j.Params[2],
-		release: int(rel),
+		repoID:    j.Params[0],
+		target:    j.Params[1],
+		source:    j.Params[2],
+		release:   int(rel),
+		skipIndex: si,
 	}, nil
 }
 
 // Execute will copy the source&rel match from the repo to the target
 func (j *CopySourceJobHandler) Execute(_ *Processor, manager *core.Manager) error {
-	if err := manager.CopySource(j.repoID, j.target, j.source, j.release); err != nil {
+	if err := manager.CopySource(j.repoID, j.target, j.source, j.release, j.skipIndex); err != nil {
 		return err
 	}
 	log.WithFields(log.Fields{
@@ -69,6 +75,7 @@ func (j *CopySourceJobHandler) Execute(_ *Processor, manager *core.Manager) erro
 		"to":            j.target,
 		"source":        j.source,
 		"releaseNumber": j.release,
+		"skipIndex":     j.skipIndex,
 	}).Info("Removed source")
 	return nil
 }

--- a/src/libferry/main.go
+++ b/src/libferry/main.go
@@ -201,11 +201,12 @@ func (c *Client) RemoveSource(repoID, sourceID string, relno int) error {
 }
 
 // CopySource will ask the backend to copy packages by source name
-func (c *Client) CopySource(fromID, targetID, sourceID string, relno int) error {
+func (c *Client) CopySource(fromID, targetID, sourceID string, relno int, skipIndex bool) error {
 	sq := CopySourceRequest{
-		Source:  sourceID,
-		Target:  targetID,
-		Release: relno,
+		Source:    sourceID,
+		Target:    targetID,
+		Release:   relno,
+		SkipIndex: skipIndex,
 	}
 	return c.postBasicResponse(c.formURI("api/v1/copy/source/"+fromID), &sq, &Response{})
 }

--- a/src/libferry/types.go
+++ b/src/libferry/types.go
@@ -79,9 +79,10 @@ type RemoveSourceRequest struct {
 // given source and relno parameters
 type CopySourceRequest struct {
 	Response
-	Target  string `json:"target"`
-	Source  string `json:"source"`
-	Release int    `json:"relno"`
+	Target    string `json:"target"`
+	Source    string `json:"source"`
+	Release   int    `json:"relno"`
+	SkipIndex bool   `json:"skipIndex"`
 }
 
 // TrimPackagesRequest is sent when trimming excessive fat from a repository.


### PR DESCRIPTION
This allows us to do a cherry-pick without automatically indexing afterwards, matching the previous behavior for when that's necessary.

This is untested, but it matches how wiring up a flag is handled in clone_repo and builds at least.