### PR TITLE
copy_source: Rename skip-index short flag to '-x'

### DIFF
--- a/src/ferryctl/cmd/copy_source.go
+++ b/src/ferryctl/cmd/copy_source.go
@@ -39,7 +39,7 @@ var copySourceCmd = &cobra.Command{
 
 func init() {
 	CopyCmd.AddCommand(copySourceCmd)
-	CopyCmd.PersistentFlags().BoolVarP(&skipIndex, "skip-index", "si", false, "Skip updating the index of the target")
+	CopyCmd.PersistentFlags().BoolVarP(&skipIndex, "skip-index", "x", false, "Skip updating the index of the target")
 }
 
 func copySource(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Was previously '-si', but shorthand flags need to be one letter.

Without this fix, ferryctl fails to start and spits out a traceback.