### PR TITLE
ferryd/jobs: Fix regression adding minimum timeout between jobs

### DIFF
--- a/src/ferryd/jobs/worker.go
+++ b/src/ferryd/jobs/worker.go
@@ -153,8 +153,9 @@ func (w *Worker) Start() {
 				}).Error("Error in retiring job")
 			}
 
-			// We had a job, so we must reset the timeout period
-			w.setTime()
+			// We had a job, so we must reset the timeout period.
+			// If we just finished a job, check again immediately
+			w.timer.Reset(0)
 		}
 	}
 }


### PR DESCRIPTION
475e018222eed373ce656ce6b74151cc0d7ddf4a added a regression where the minWait and jitter was added after every successful operation.

This caused a no-op delta run where no deltas needed to actually be generated take 44mins instead of 7s against the legacy shannon repo...

This also significally speeds up the delta run where as a full delta run against the entire shannon repo would previously take 1h:16mins with xz -T 16 and now takes 44mins with xz -T 8.